### PR TITLE
canvas get호출 오류 해결

### DIFF
--- a/src/main/java/com/lslt/l_place/config/WebConfig.java
+++ b/src/main/java/com/lslt/l_place/config/WebConfig.java
@@ -16,9 +16,12 @@ public class WebConfig implements WebMvcConfigurer {
      */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**") // 모든 URL 패턴에 대해 CORS 설정 적용
-                .allowedOrigins("http://localhost:3000")  // React 개발 서버
-                .allowedMethods("GET", "POST", "PUT") // 필요한 메서드만 허용
-                .allowCredentials(true);  // 자격 증명 허용
+        registry.addMapping("/**") // 모든 URL 패턴에 대해 CORS 허용
+                .allowedOrigins("*") // Swagger UI에서 요청 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 필요한 HTTP 메서드
+                .allowedHeaders("*") // 모든 헤더 허용
+                .exposedHeaders("Authorization") // 필요한 헤더 추가
+                .allowCredentials(false); // 자격 증명 허용 설정
     }
+
 }

--- a/src/main/java/com/lslt/l_place/controller/CanvasController.java
+++ b/src/main/java/com/lslt/l_place/controller/CanvasController.java
@@ -37,4 +37,20 @@ public class CanvasController {
         }
         return canvasService.updatePixel(pixelDTO.getX(), pixelDTO.getY(), pixelDTO.getColor());
     }
+
+    /**
+     * 특정 x, y 좌표의 픽셀 색상을 반환합니다.
+     * @param x x 좌표
+     * @param y y 좌표
+     * @return 해당 픽셀의 색상 정보
+     */
+    @GetMapping("/pixel")
+    public PixelDTO getPixel(@RequestParam int x, @RequestParam int y) {
+        if (x < 0 || x >= 256 || y < 0 || y >= 256) {
+            throw new IllegalArgumentException("Invalid pixel coordinates.");
+        }
+        return canvasService.getPixel(x, y);
+    }
+
+
 }

--- a/src/main/java/com/lslt/l_place/dto/PixelDTO.java
+++ b/src/main/java/com/lslt/l_place/dto/PixelDTO.java
@@ -20,4 +20,13 @@ public class PixelDTO{
             message = "색상 코드는 #RRGGBB 또는 #RGB 형식이어야 합니다."
     )
     private final String color;
+
+    @Override
+    public String toString() {
+        return "PixelDTO{" +
+                "x=" + x +
+                ", y=" + y +
+                ", color='" + color + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/lslt/l_place/service/CanvasService.java
+++ b/src/main/java/com/lslt/l_place/service/CanvasService.java
@@ -24,4 +24,5 @@ public interface CanvasService {
      */
     PixelDTO updatePixel(int x, int y, String color);
 
+    PixelDTO getPixel(int x, int y);
 }

--- a/src/main/java/com/lslt/l_place/service/CanvasServiceImpl.java
+++ b/src/main/java/com/lslt/l_place/service/CanvasServiceImpl.java
@@ -2,16 +2,16 @@ package com.lslt.l_place.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lslt.l_place.dto.PixelDTO;
+import java.nio.ByteBuffer;
 import io.micrometer.core.annotation.Timed;
 import org.springframework.data.redis.connection.RedisConnection;
 import java.util.ArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.connection.BitFieldSubCommands;
-import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -20,6 +20,7 @@ public class CanvasServiceImpl implements CanvasService {
     private static final int CANVAS_HEIGHT = 256;
     private static final int CANVAS_WIDTH = 256;
     private static final String CANVAS_KEY = "canvas";
+    private static final Logger log = LoggerFactory.getLogger(CanvasServiceImpl.class);
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
@@ -41,17 +42,16 @@ public class CanvasServiceImpl implements CanvasService {
 
         // 각 픽셀의 24비트 컬러값을 순차적으로 읽어옴
         // 데이터를 순차적으로 읽으며 24비트씩 분리
-        for (int y = 0; y < CANVAS_HEIGHT; y++) {
-            for (int x = 0; x < CANVAS_WIDTH; x++) {
-                int offset = (y * CANVAS_WIDTH + x) * 3; // 바이트 단위로 3씩 이동 (24비트 = 3바이트)
-
-                if (offset + 3 <= data.length) { // 안전하게 바이트 접근
-                    int color = ((data[offset] & 0xFF) << 16) | // R
-                            ((data[offset + 1] & 0xFF) << 8) | // G
-                            (data[offset + 2] & 0xFF); // B
-
-                    // 결과값을 16진수로 변환
-                    String hexColor = String.format("#%06X", color);
+        //byteBuffer로 속도 향상
+        if (data != null) {
+            ByteBuffer buffer = ByteBuffer.wrap(data);
+            for (int y = 0; y < CANVAS_HEIGHT; y++) {
+                for (int x = 0; x < CANVAS_WIDTH; x++) {
+                    // 3바이트씩 읽어서 한 번에 처리
+                    int r = buffer.get() & 0xFF;
+                    int g = buffer.get() & 0xFF;
+                    int b = buffer.get() & 0xFF;
+                    String hexColor = String.format("#%02X%02X%02X", r, g, b);
                     canvas.add(new PixelDTO(x, y, hexColor));
                 }
             }
@@ -72,20 +72,29 @@ public class CanvasServiceImpl implements CanvasService {
         };
 
         RedisConnection connection = redisTemplate.getConnectionFactory().getConnection();
-        byte[] canvasData = connection.get(CANVAS_KEY.getBytes());
+        // 현재 색상값 읽어오기
+        List<Long> result = connection.bitField(
+                CANVAS_KEY.getBytes(),
+                BitFieldSubCommands.create()
+                        .get(BitFieldSubCommands.BitFieldType.unsigned(24))
+                        .valueAt(offset)
+        );
 
-        // Redis 데이터가 없으면 초기화
-        if (canvasData == null || canvasData.length < (CANVAS_WIDTH * CANVAS_HEIGHT * 3)) {
-            canvasData = new byte[CANVAS_WIDTH * CANVAS_HEIGHT * 3];
-            Arrays.fill(canvasData, (byte) 0xFF); // 초기화: 흰색으로 설정
+        // 현재 색상값이 같으면 null 반환
+        if (result != null && !result.isEmpty() && result.get(0) == colorValue) {
+            log.info("같은 위치 같은 색");
+            return null;
         }
 
-        // 픽셀 데이터 업데이트
-        System.arraycopy(pixelData, 0, canvasData, offset, pixelData.length);
-        connection.set(CANVAS_KEY.getBytes(), canvasData);
+        connection.bitField(
+                CANVAS_KEY.getBytes(),
+                BitFieldSubCommands.create()
+                        .set(BitFieldSubCommands.BitFieldType.unsigned(24))
+                        .valueAt(offset)
+                        .to(colorValue)
+        );
 
-        // Pub/Sub 메시지 전송
-        PixelDTO pixelDTO = new PixelDTO(x, y, color);
+        PixelDTO pixelDTO = new PixelDTO(x, y , color);
         redisTemplate.convertAndSend("canvas-update", serialize(pixelDTO));
 
         return pixelDTO;


### PR DESCRIPTION
## 원인

기존 로직의 문제점은 연속된 위치에서 픽셀을 찍으면 redis에 들어가는 데이터가 byte배열 상 바로 옆 위치에 있는 데이터가 존재할 때 서로가 꼬인채로 저장이 됩니다. 예) 0x65 0xe1 저장 시 0x43 0xfe 로 서로가 영향이 간 채로 저장이 됨

## 해결

성능적인 부분에서는 큰 문제가 없어서 비트필드 관련 로직을 초기 코드처럼 단순 로직으로 해결
